### PR TITLE
Add .NET gitignore to exclude build artifacts and Zone.Identifier files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Ignore build output directories
+bin/
+obj/
+
+# Ignore Windows zone identifier files
+*Zone.Identifier


### PR DESCRIPTION
## Summary
- add root .gitignore ignoring bin/ and obj/ directories
- exclude Windows Zone.Identifier files from version control

## Testing
- `dotnet build Library/Library.csproj` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ad582763248325b93dc9c710b44524