### PR TITLE
Add Docker Compose configuration

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '3.8'
+services:
+  api:
+    build:
+      context: .
+      dockerfile: API/Dockerfile
+    ports:
+      - "7071:80"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary
- add Docker Compose file to build and run the API container

## Testing
- `curl http://localhost:7071 -I`
- `docker compose up --build` *(fails: docker: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68ad65259c8083259160375c6c84424a